### PR TITLE
Add correct link to the has_many association reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ form builder view helpers. Here are some hints:
 
 ## References
 
-* [`has_many` association reference](https://guides.rubyonrails.org/association_basics.html#has-one-association-reference)
+* [`has_many` association reference](https://guides.rubyonrails.org/association_basics.html#has-many-association-reference)
 * [`belongs_to` association reference](https://guides.rubyonrails.org/association_basics.html#belongs-to-association-reference)
 * [`accepts_nested_attributes_for`](https://apidock.com/rails/v5.2.3/ActiveRecord/NestedAttributes/ClassMethods/accepts_nested_attributes_for)
 * [Specifying which parameters are accepted in Rails Controllers](https://apidock.com/rails/ActionController/Parameters/permit)


### PR DESCRIPTION
Originally, the link labeled '`has_many` association reference' went to the has_one association reference instead.
It now correctly goes to the has_many association reference.